### PR TITLE
fix: Correct AS206729 organization name

### DIFF
--- a/ruleset/ASN.China.list
+++ b/ruleset/ASN.China.list
@@ -929,7 +929,7 @@ IP-ASN,149648 // Fuzhou Lefeng Networks Technology Co., Ltd.
 IP-ASN,149790 // Octopus Cloud Computing (Shanghai) Co., Ltd
 IP-ASN,149795 // XiaoJin233 Network
 IP-ASN,205794 // JINZE YANG
-IP-ASN,206729 // YANGYINGTAO
+IP-ASN,206729 // Vincent Yang
 IP-ASN,208191 // MINGWEI LI
 IP-ASN,208577 // Chaohui Liu
 IP-ASN,208679 // YIKAI-ZHAO


### PR DESCRIPTION
Hello,

I am the operator of AS206729. I changed the ASN organization name from `YANGYINGTAO` to `Vincent Yang` today.

[https://bgp.tools/as/206729#whois](https://bgp.tools/as/206729#whois)

