### PR TITLE
Replace Alibaba DNS-over-HTTPS (DoH) with DNS-over-QUIC (DoQ)

### DIFF
--- a/sgmodule/DNS.sgmodule
+++ b/sgmodule/DNS.sgmodule
@@ -148,44 +148,44 @@ networking.apple = server:https://doh.dns.apple.com/dns-query // Apple
 
 # > 阿里巴巴
 # refer: https://www.alidns.com
-*.alibaba.cn = server:https://dns.alidns.com/dns-query // 阿里巴巴
-*.alibaba.com.cn = server:https://dns.alidns.com/dns-query // 阿里巴巴
-*.china.alibaba.com = server:https://dns.alidns.com/dns-query // Alibaba 中国
-*.1688.com = server:https://dns.alidns.com/dns-query // 1688
-*.taobao.com = server:https://dns.alidns.com/dns-query // 淘宝
-*.tbcache.com = server:https://dns.alidns.com/dns-query // 淘宝 缓存
-*.tmall.com = server:https://dns.alidns.com/dns-query // 天猫
-*.alicdn.com = server:https://dns.alidns.com/dns-query // 阿里 CDN
-*.alikunlun.com = server:https://dns.alidns.com/dns-query // 阿里昆仑
-*.aliapp.com = server:https://dns.alidns.com/dns-query // 云引擎应用平台
-*.aliapp.org = server:https://dns.alidns.com/dns-query // 上云平台
-*.alibabausercontent.com = server:https://dns.alidns.com/dns-query // 阿里用户上传资料
-*.mmstat.com = server:https://dns.alidns.com/dns-query // mmstat 数据统计 广告追踪
-tb.cn = server:https://dns.alidns.com/dns-query // 淘宝短网址
+*.alibaba.cn = server:quic://dns.alidns.com // 阿里巴巴
+*.alibaba.com.cn = server:quic://dns.alidns.com // 阿里巴巴
+*.china.alibaba.com = server:quic://dns.alidns.com // Alibaba 中国
+*.1688.com = server:quic://dns.alidns.com // 1688
+*.taobao.com = server:quic://dns.alidns.com // 淘宝
+*.tbcache.com = server:quic://dns.alidns.com // 淘宝 缓存
+*.tmall.com = server:quic://dns.alidns.com // 天猫
+*.alicdn.com = server:quic://dns.alidns.com // 阿里 CDN
+*.alikunlun.com = server:quic://dns.alidns.com // 阿里昆仑
+*.aliapp.com = server:quic://dns.alidns.com // 云引擎应用平台
+*.aliapp.org = server:quic://dns.alidns.com // 上云平台
+*.alibabausercontent.com = server:quic://dns.alidns.com // 阿里用户上传资料
+*.mmstat.com = server:quic://dns.alidns.com // mmstat 数据统计 广告追踪
+tb.cn = server:quic://dns.alidns.com // 淘宝短网址
 
 # > 阿里云
 # refer: https://www.alidns.com
-*.aliyun.* = server:https://dns.alidns.com/dns-query // 阿里云
-*.aliyuncdn.* = server:https://dns.alidns.com/dns-query // 阿里云 CDN
-*.aliyuncs.com = server:https://dns.alidns.com/dns-query // 阿里云 API 服务
-*.aliyunddos????.com = server:https://dns.alidns.com/dns-query // 阿里云 DDoS防护
-*.aliyundrive.com = server:https://dns.alidns.com/dns-query // 阿里云盘
-*.aliyundun.com = server:https://dns.alidns.com/dns-query // 阿里云盾
-*.aliyundunwaf.com = server:https://dns.alidns.com/dns-query // 阿里云盾 Web 应用防火墙
-*.aliyun-inc.com = server:https://dns.alidns.com/dns-query // 阿里云 内部
+*.aliyun.* = server:quic://dns.alidns.com // 阿里云
+*.aliyuncdn.* = server:quic://dns.alidns.com // 阿里云 CDN
+*.aliyuncs.com = server:quic://dns.alidns.com // 阿里云 API 服务
+*.aliyunddos????.com = server:quic://dns.alidns.com // 阿里云 DDoS防护
+*.aliyundrive.com = server:quic://dns.alidns.com // 阿里云盘
+*.aliyundun.com = server:quic://dns.alidns.com // 阿里云盾
+*.aliyundunwaf.com = server:quic://dns.alidns.com // 阿里云盾 Web 应用防火墙
+*.aliyun-inc.com = server:quic://dns.alidns.com // 阿里云 内部
 
 # > 蚂蚁集团
 # refer: https://www.alidns.com
-*.antgroup.com = server:https://dns.alidns.com/dns-query // 蚂蚁集团
-*.antfin.com = server:https://dns.alidns.com/dns-query // 蚂蚁金服
-*.antfinancial.com = server:https://dns.alidns.com/dns-query // 蚂蚁金服
-*.alipay.com = server:https://dns.alidns.com/dns-query // 支付宝
-*.alipay.com.cn = server:https://dns.alidns.com/dns-query // 支付宝
-*.alipaydns.com = server:https://dns.alidns.com/dns-query // 支付宝 HTTP DNS
-*.alipayeshop.com = server:https://dns.alidns.com/dns-query // 支付宝 商家资源
-*.alipaylog.com = server:https://dns.alidns.com/dns-query // 支付宝 Mdap
-*.alipayobjects.com = server:https://dns.alidns.com/dns-query // 支付宝 静态资源
-*.alipay-eco.com = server:https://dns.alidns.com/dns-query // 支付宝 开放技术生态体系
+*.antgroup.com = server:quic://dns.alidns.com // 蚂蚁集团
+*.antfin.com = server:quic://dns.alidns.com // 蚂蚁金服
+*.antfinancial.com = server:quic://dns.alidns.com // 蚂蚁金服
+*.alipay.com = server:quic://dns.alidns.com // 支付宝
+*.alipay.com.cn = server:quic://dns.alidns.com // 支付宝
+*.alipaydns.com = server:quic://dns.alidns.com // 支付宝 HTTP DNS
+*.alipayeshop.com = server:quic://dns.alidns.com // 支付宝 商家资源
+*.alipaylog.com = server:quic://dns.alidns.com // 支付宝 Mdap
+*.alipayobjects.com = server:quic://dns.alidns.com // 支付宝 静态资源
+*.alipay-eco.com = server:quic://dns.alidns.com // 支付宝 开放技术生态体系
 
 # > 腾讯
 # refer: https://www.dnspod.cn/products/publicdns
@@ -306,9 +306,9 @@ urlqh.cn = server:https://doh.360.cn/dns-query // 360短网址
 *.zjcdn.com = server:180.184.1.1 // 字节跳动 CDN
 
 # > BiliBili
-upos-sz-mirrorali.bilivideo.com = server:https://dns.alidns.com/dns-query // BiliBili upos视频服务器（阿里云）
-upos-sz-mirrorali?.bilivideo.com = server:https://dns.alidns.com/dns-query // BiliBili upos视频服务器（阿里云）
-upos-sz-mirrorali??.bilivideo.com = server:https://dns.alidns.com/dns-query // BiliBili upos视频服务器（阿里云）
+upos-sz-mirrorali.bilivideo.com = server:quic://dns.alidns.com // BiliBili upos视频服务器（阿里云）
+upos-sz-mirrorali?.bilivideo.com = server:quic://dns.alidns.com // BiliBili upos视频服务器（阿里云）
+upos-sz-mirrorali??.bilivideo.com = server:quic://dns.alidns.com // BiliBili upos视频服务器（阿里云）
 upos-sz-mirrorbos.bilivideo.com = server:180.76.76.76 // BiliBili upos视频服务器（百度云）
 upos-sz-mirrorcos.bilivideo.com = server:https://doh.pub/dns-query // BiliBili upos视频服务器（腾讯云）
 upos-sz-mirrorcos?.bilivideo.com = server:https://doh.pub/dns-query // BiliBili upos视频服务器（腾讯云）


### PR DESCRIPTION
Switched from Alibaba's DNS-over-HTTPS (DoH) service to their DNS-over-QUIC (DoQ) service to take advantage of QUIC's improved connection security and performance features. This change aims to enhance the security and efficiency of DNS queries within our infrastructure.